### PR TITLE
fix:make compilation error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ builds/android_ndk_jni_mk/libs
 builds/android_ndk_jni_mk/obj
 *.opensdf
 *.sdf
+tinyuz

--- a/compress/tuz_enc_private/tuz_enc_match.cpp
+++ b/compress/tuz_enc_private/tuz_enc_match.cpp
@@ -239,7 +239,7 @@ void TMatch::_initCost(std::vector<TUInt>& cost,size_t costSize){
     cost.resize(costSize,kNullCostValue);
     matchLen.resize(costSize,0);
     dictPos.clear();
-    dictPos.resize(costSize,~(size_t)0);
+    dictPos.resize(costSize,~(TPosInt)0);
     cost[0]=0;
     dictPos[0]=0;
     matchLen[0]=0;


### PR DESCRIPTION
```sh
tinyuz/compress/tuz_enc_private/tuz_enc_match.cpp: In member function 'void _tuz_private::TMatch::_initCost(std::vector<unsigned int>&, size_t)':
tinyuz/compress/tuz_enc_private/tuz_enc_match.cpp:242:29: warning: conversion from 'size_t' {aka 'long long unsigned int'} to 'std::vector<unsigned int>::value_type' {aka 'unsigned int'} changes value from '18446744073709551615' to '4294967295' [-Woverflow]
dictPos.resize(costSize,~(size_t)0);
```